### PR TITLE
Fix capitalization in build-honeytrap-agent.sh

### DIFF
--- a/debian/build-honeytrap-agent.sh
+++ b/debian/build-honeytrap-agent.sh
@@ -21,6 +21,6 @@ go build -a -ldflags "$LDFLAGS -extldflags \"-static\"" -o /go/bin/app
 cd /build
 cp /go/bin/app honeytrap-agent/usr/bin/honeytrap-agent
 
-cat honeytrap-agent/DEBIAN/control.template | sed -e s/#DATE#/$DATE/ | sed -e s/#COMMIT#/$COMMIT/ > honeytrap-agent/debian/control
+cat honeytrap-agent/DEBIAN/control.template | sed -e s/#DATE#/$DATE/ | sed -e s/#COMMIT#/$COMMIT/ > honeytrap-agent/DEBIAN/control
 
 dpkg-deb --build honeytrap-agent 


### PR DESCRIPTION
On my machine this is case-sensitive, so the writing of the control file would result in
```
/build/build-honeytrap-agent.sh: 24: /build/build-honeytrap-agent.sh: cannot create honeytrap-agent/debian/control: Directory nonexistent
dpkg-deb: error: failed to open package info file 'honeytrap-agent/DEBIAN/control' for reading: No such file or directory
```
This PR fixes this.