### PR TITLE
Fix postinstall for agent build

### DIFF
--- a/debian/honeytrap-agent/DEBIAN/postinst
+++ b/debian/honeytrap-agent/DEBIAN/postinst
@@ -1,5 +1,8 @@
 #!/bin/bash
 adduser --system --no-create-home honeytrap-agent
 
+mkdir /var/lib/honeytrap-agent
+mkdir /var/log/honeytrap-agent
+
 chown -R honeytrap-agent /var/lib/honeytrap-agent
 chown -R honeytrap-agent /var/log/honeytrap-agent

--- a/debian/honeytrap-agent/DEBIAN/postinst
+++ b/debian/honeytrap-agent/DEBIAN/postinst
@@ -1,8 +1,8 @@
 #!/bin/bash
 adduser --system --no-create-home honeytrap-agent
 
-mkdir /var/lib/honeytrap-agent
-mkdir /var/log/honeytrap-agent
+mkdir -p /var/lib/honeytrap-agent
+mkdir -p /var/log/honeytrap-agent
 
 chown -R honeytrap-agent /var/lib/honeytrap-agent
 chown -R honeytrap-agent /var/log/honeytrap-agent


### PR DESCRIPTION
The current postinstall script tries to `chown` folders that don't exist yet. This PR first creates the dirs before `chown`ing them